### PR TITLE
Added a rejectUnauthorized option to ignore ssl errors.

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -130,6 +130,10 @@ FetchStream.prototype.normalizeOptions = function(){
         }
     }
 
+    // rejectUnauthorized
+    if (typeof this.options.rejectUnauthorized === 'undefined') {
+      this.options.rejectUnauthorized = true;
+    }
 }
 
 FetchStream.prototype.parseUrl = function(url){
@@ -139,7 +143,8 @@ FetchStream.prototype.parseUrl = function(url){
             host: urlparts.hostname || urlparts.host,
             port: urlparts.port,
             path: urlparts.pathname + (urlparts.search || "") || "/",
-            method: this.options.method
+            method: this.options.method,
+            rejectUnauthorized: this.options.rejectUnauthorized
         };
 
     if("agent" in this.options){


### PR DESCRIPTION
This will add the option 'rejectUnauthorized' to ignore ssl errors (e.g. Cert. expired).
