### PR TITLE
Redirect to https caused uncatchable problem when a http.agent was given

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Possible option values
  * **overrideCharset** valid for `fetchUrl`, set input encoding
  * **asyncDnsLoookup** use high performance asyncronous DNS resolution based on c-ares instead of a thread pool calling getaddrinfo(3)
  * **timeout** set a timeout in ms
- * **agent** pass-through http.request agent parameter
+ * **agentHttps** pass-through http.request agent parameter for https
+ * **agentHttp** pass-through http.request agent parameter for http
+ * **agent** pass-through http.request agent parameter as fallback, if agentHttps or agentHttp are not specified
  * **rejectUnauthorized** whether to reject self-signed certificates (`true`, default behavior), or ignore and allow them (`false`)
 
 

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -169,10 +169,6 @@ FetchStream.prototype.parseUrl = function (url) {
             rejectUnauthorized: this.options.rejectUnauthorized
         };
 
-    if ('agent' in this.options) {
-        urloptions.agent = this.options.agent;
-    }
-
     switch (urlparts.protocol) {
         case 'https:':
             transport = https;
@@ -181,6 +177,22 @@ FetchStream.prototype.parseUrl = function (url) {
         default:
             transport = http;
             break;
+    }
+
+    if (transport === https) {
+        if("agentHttps" in this.options){
+            urloptions.agent = this.options.agentHttps;
+        }
+        if("agent" in this.options){
+            urloptions.agent = this.options.agent;
+        }
+    } else {
+        if("agentHttp" in this.options){
+            urloptions.agent = this.options.agentHttp;
+        }
+        if("agent" in this.options){
+            urloptions.agent = this.options.agent;
+        }
     }
 
     if (!urloptions.port) {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -180,17 +180,17 @@ FetchStream.prototype.parseUrl = function (url) {
     }
 
     if (transport === https) {
-        if("agentHttps" in this.options){
+        if('agentHttps' in this.options){
             urloptions.agent = this.options.agentHttps;
         }
-        if("agent" in this.options){
+        if('agent' in this.options){
             urloptions.agent = this.options.agent;
         }
     } else {
-        if("agentHttp" in this.options){
+        if('agentHttp' in this.options){
             urloptions.agent = this.options.agentHttp;
         }
-        if("agent" in this.options){
+        if('agent' in this.options){
             urloptions.agent = this.options.agent;
         }
     }


### PR DESCRIPTION
Given the following code:

    var agent = new http.Agent();
    var fetch = new FetchStream("http://startpage.com",{
        agent : agent
    });

The server would redirect to https:// and node.js would throw an error. To fix this, we need to be able to give agents for http and https.

To preserve the old API, options.agent is still possible and used as fallback, if the corresponding options.agentHttp or options.agentHttps are not given.

The readme has been updated accordingly.