### PR TITLE
Support for node v6.0.0

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -38,7 +38,14 @@ function FetchStream(url, options) {
     } else {
         process.nextTick(this.runStream.bind(this, url));
     }
-    this.responseBuffer = new Buffer.alloc(0, '', 'binary');
+
+    var nodeVer = process.versions.node.split('.')[0];
+    if (nodeVer >= 6) {
+        this.responseBuffer = new Buffer.alloc(0, '', 'binary');
+    } else {
+        this.responseBuffer = new Buffer(0, 'binary');
+    }
+
     this.ended = false;
     this.readyToRead = 0;
 }
@@ -69,7 +76,13 @@ FetchStream.prototype.drainBuffer = function () {
         this.responseBuffer.copy(rest, 0, this.readyToRead);
     } else {
         push = this.responseBuffer;
-        rest = new Buffer.alloc(0, '', 'binary');
+        var nodeVer = process.versions.node.split('.')[0];
+        if (nodeVer >= 6) {
+            rest = new Buffer.alloc(0, '', 'binary');
+        } else {
+            rest = new Buffer(0, 'binary');
+        }
+
     }
     this.responseBuffer = rest;
     this.readyToRead = 0;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -41,7 +41,7 @@ function FetchStream(url, options) {
 
     var nodeVer = process.versions.node.split('.')[0];
     if (nodeVer >= 6) {
-        this.responseBuffer = new Buffer.alloc(0, '', 'binary');
+        this.responseBuffer = Buffer.alloc(0, '', 'binary');
     } else {
         this.responseBuffer = new Buffer(0, 'binary');
     }
@@ -78,7 +78,7 @@ FetchStream.prototype.drainBuffer = function () {
         push = this.responseBuffer;
         var nodeVer = process.versions.node.split('.')[0];
         if (nodeVer >= 6) {
-            rest = new Buffer.alloc(0, '', 'binary');
+            rest = Buffer.alloc(0, '', 'binary');
         } else {
             rest = new Buffer(0, 'binary');
         }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -38,7 +38,7 @@ function FetchStream(url, options) {
     } else {
         process.nextTick(this.runStream.bind(this, url));
     }
-    this.responseBuffer = new Buffer(0, 'binary');
+    this.responseBuffer = new Buffer.alloc(0, '', 'binary');
     this.ended = false;
     this.readyToRead = 0;
 }
@@ -69,7 +69,7 @@ FetchStream.prototype.drainBuffer = function () {
         this.responseBuffer.copy(rest, 0, this.readyToRead);
     } else {
         push = this.responseBuffer;
-        rest = new Buffer(0, 'binary');
+        rest = new Buffer.alloc(0, '', 'binary');
     }
     this.responseBuffer = rest;
     this.readyToRead = 0;


### PR DESCRIPTION
I apologize for the double, but I couldn't see where I could tell github to use the latest commit, rather than the first commit. 

Two changes to support node v6.0.0, based on depreciations, listed here: https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_new_buffer_size

This also supports pre-v6 Buffer.

